### PR TITLE
fix: update GPU utilization mapping to use UUID instead of device name (#441)

### DIFF
--- a/frontend/src/components/system-monitor-sidebar.tsx
+++ b/frontend/src/components/system-monitor-sidebar.tsx
@@ -239,7 +239,7 @@ export function SystemMonitorSidebar({
                     gpuData.isLoading
                       ? 0
                       : (gpuData.data?.gpuUtilizations.find(
-                          (gpu: GpuUtilization) => gpu.device === chart.device,
+                          (gpu: GpuUtilization) => gpu.uuid === chart.id,
                         )?.value ?? 0)
                   }
                   isLoading={gpuData.isLoading}


### PR DESCRIPTION
fix: update GPU utilization mapping to use UUID instead of device name (#441)